### PR TITLE
Change version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dependencies {
     // Use the following line to include client library from Maven Central Repository
     // Change the version number from the search.maven.org result
     //
-    compile 'com.microsoft.projectoxford:speechrecognition:2.1.0'
+    compile 'com.microsoft.projectoxford:speechrecognition:1.1.0'
 
     // Your other Dependencies...
 }


### PR DESCRIPTION
The correct version should be 1.1.0, not 2.1.0. This was confusing to me because it was failing to compile. Seems like a simple typo.